### PR TITLE
fix shell script bug in arm-cloudimage.md

### DIFF
--- a/src/v0.8.6/en/advanced/arm-cloudimage.md
+++ b/src/v0.8.6/en/advanced/arm-cloudimage.md
@@ -9,7 +9,7 @@ wget https://github.com/sealerio/sealer/releases/download/v0.8.5/sealer-v0.8.5-l
 ## Run a cluster on ARM platform
 
 ```shell script
-sealer run kubernetes:v1.19.8 --master 192.168.0.3 --passwd xxx
+sealer run kubernetes:v1.19.8 --masters 192.168.0.3 --passwd xxx
 ```
 
 ## Build an ARM cloud image

--- a/src/v0.8.6/zh/advanced/arm-cloudimage.md
+++ b/src/v0.8.6/zh/advanced/arm-cloudimage.md
@@ -11,5 +11,5 @@ wget https://github.com/sealerio/sealer/releases/download/v0.5.0/sealer-v0.5.0-l
 Just using the ARM CloudImage `kubernetes-arm64:v1.19.7`:
 
 ```shell script
-sealer run kubernetes-arm64:v1.19.7 --master 192.168.0.3 --passwd xxx
+sealer run kubernetes-arm64:v1.19.7 --masters 192.168.0.3 --passwd xxx
 ```


### PR DESCRIPTION
Signed-off-by: Lancelot <1984737645@qq.com>

<!--  Thanks for submitting a pull request! Here are some tips for you:
1. Please make sure you have read and understood the contributing guidelines: https://github.com/alibaba/blob/master/CONTRIBUTING.md
2. Please make sure the PR has a corresponding issue.
-->

### Describe what this PR does / why we need it


```
sealer run kubernetes-arm64:v1.19.7 --master 192.168.0.3 --passwd xxx
```
<img width="753" alt="image" src="https://user-images.githubusercontent.com/53330071/201524854-d9b68723-fe23-450c-9e09-06a86a3bc105.png">

<img width="1155" alt="image" src="https://user-images.githubusercontent.com/53330071/201524688-caa528f0-adf1-4445-abd3-cdc21974ba37.png">

When I read the ARM CloudImage file in the official documentation, I found a problem, I changed `master` to `masters`.

BTW, there still some problem, after I changed it.
```
[ERROR] [root.go:70] sealer-v0.8.6: failed to get digest: failed to get digest from manifest list: no manifest of the corresponding platform
```
### Does this pull request fix one issue?

<!--If that, add "Fixes #xxxx" below in the next line. For example, Fixes #15. Otherwise, add "NONE" -->

### Describe how you did it


### Describe how to verify it


### Special notes for reviews
